### PR TITLE
Add manual ORBX merge workflow

### DIFF
--- a/LMI_OctaneShotManager_Blender/Workflows/manual_merge/manual_merge_workflow.py
+++ b/LMI_OctaneShotManager_Blender/Workflows/manual_merge/manual_merge_workflow.py
@@ -1,0 +1,65 @@
+import bpy
+from bpy.types import PropertyGroup, Operator, UIList
+from bpy.props import StringProperty
+
+
+class ManualMergeSourceItem(PropertyGroup):
+    path: StringProperty(name="Source ORBX", subtype='FILE_PATH')
+
+
+class LMB_UL_manual_merge_sources(UIList):
+    def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
+        layout.prop(item, "path", text="", emboss=False)
+
+
+class LMB_OT_manual_merge_source_add(Operator):
+    bl_idname = "lmb.manual_merge_source_add"
+    bl_label = "Add ORBX Source"
+    bl_description = "Add an ORBX file to merge"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    filepath: StringProperty(subtype='FILE_PATH')
+
+    def execute(self, context):
+        props = context.scene.otpc_props
+        item = props.manual_merge_sources.add()
+        item.path = self.filepath
+        props.manual_merge_sources_index = len(props.manual_merge_sources) - 1
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        context.window_manager.fileselect_add(self)
+        return {'RUNNING_MODAL'}
+
+
+class LMB_OT_manual_merge_source_remove(Operator):
+    bl_idname = "lmb.manual_merge_source_remove"
+    bl_label = "Remove ORBX Source"
+    bl_description = "Remove the selected ORBX source file"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    def execute(self, context):
+        props = context.scene.otpc_props
+        idx = props.manual_merge_sources_index
+        if 0 <= idx < len(props.manual_merge_sources):
+            props.manual_merge_sources.remove(idx)
+            props.manual_merge_sources_index = min(idx, len(props.manual_merge_sources) - 1)
+        return {'FINISHED'}
+
+
+classes = (
+    ManualMergeSourceItem,
+    LMB_UL_manual_merge_sources,
+    LMB_OT_manual_merge_source_add,
+    LMB_OT_manual_merge_source_remove,
+)
+
+
+def register():
+    for cls in classes:
+        bpy.utils.register_class(cls)
+
+
+def unregister():
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)

--- a/LMI_OctaneShotManager_Blender/Workflows/manual_merge/utils.py
+++ b/LMI_OctaneShotManager_Blender/Workflows/manual_merge/utils.py
@@ -1,0 +1,79 @@
+import bpy
+import os
+from ..TAGs.utils import _ORBX_RE
+
+
+def parse_orbx_filename(path):
+    """Return (base, part_no, start, end) tuple if name matches the ORBX pattern."""
+    name = os.path.basename(path)
+    m = _ORBX_RE.match(name)
+    if not m:
+        return None
+    return (
+        m.group("base"),
+        int(m.group("part")),
+        int(m.group("start")),
+        int(m.group("end")),
+    )
+
+
+def build_manual_merge_tasks(dest_path, source_paths, save_dir, base_name):
+    """Build merge tasks for :func:`make_orbx_merge_manager`.
+
+    Parameters
+    ----------
+    dest_path : str
+        Path to the destination ORBX file used for all merges.
+    source_paths : list[str]
+        List of ORBX files to merge with the destination.
+    save_dir : str
+        Directory where merged ORBX files will be saved.
+    base_name : str
+        Base name for the output files.
+    """
+    all_paths = [dest_path] + list(source_paths)
+    resolved = []
+    for p in all_paths:
+        abspath = os.path.abspath(bpy.path.abspath(p)) if hasattr(bpy, 'path') else os.path.abspath(p)
+        if not os.path.isfile(abspath):
+            raise FileNotFoundError(abspath)
+        resolved.append(abspath)
+    dest_abspath = resolved[0]
+    src_abspaths = resolved[1:]
+
+    chunk_sizes = set()
+    groups = {}
+
+    info = parse_orbx_filename(dest_abspath)
+    if info:
+        chunk_sizes.add(info[3] - info[2] + 1)
+
+    for path in src_abspaths:
+        info = parse_orbx_filename(path)
+        if info:
+            start, end = info[2], info[3]
+            chunk_sizes.add(end - start + 1)
+            groups.setdefault((start, end), []).append(path)
+        else:
+            groups.setdefault(None, []).append(path)
+
+    if len(chunk_sizes) > 1:
+        raise ValueError("All ORBX files must use the same chunk size")
+
+    tasks = []
+    generic = groups.get(None, [])
+    ranges = sorted(k for k in groups.keys() if k is not None)
+
+    if not ranges:
+        save_path = os.path.join(save_dir, f"{base_name}.orbx")
+        tasks.append([save_path, dest_abspath] + generic)
+        return tasks
+
+    for part_no, (start, end) in enumerate(ranges, 1):
+        name = f"{base_name}_pt{part_no}_{start:03d}-{end:03d}.orbx"
+        save_path = os.path.join(save_dir, name)
+        files = groups[(start, end)]
+        task = [save_path, dest_abspath] + generic + files
+        tasks.append(task)
+
+    return tasks

--- a/LMI_OctaneShotManager_Blender/exporters/orbx_manual_merge.py
+++ b/LMI_OctaneShotManager_Blender/exporters/orbx_manual_merge.py
@@ -1,0 +1,65 @@
+import os
+import bpy
+from bpy.types import Operator
+
+from ..utils import ensure_directory, resolve_octane_executable
+from ..Workflows.manual_merge.utils import build_manual_merge_tasks
+from ..Workflows.TAGs.utils import make_orbx_merge_manager
+
+
+class LMB_OT_manual_orbx_merge(Operator):
+    bl_idname = "lmb.manual_orbx_merge"
+    bl_label = "Manual ORBX Merge"
+    bl_description = "Merge selected ORBX files using Octane Standalone"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    def execute(self, context):
+        props = context.scene.otpc_props
+
+        dest = bpy.path.abspath(props.manual_merge_destination)
+        sources = [bpy.path.abspath(item.path) for item in props.manual_merge_sources]
+        save_dir = bpy.path.abspath(props.manual_merge_save_dir)
+        base_name = props.manual_merge_scene_name
+
+        ensure_directory(save_dir)
+
+        try:
+            tasks = build_manual_merge_tasks(dest, sources, save_dir, base_name)
+        except (FileNotFoundError, ValueError) as exc:
+            self.report({'ERROR'}, f"[ShotManager] {exc}")
+            return {'CANCELLED'}
+
+        if not props.manual_merge_overwrite:
+            tasks = [t for t in tasks if not os.path.exists(t[0])]
+            if not tasks:
+                self.report({'INFO'}, "[ShotManager] All merged files exist. Enable Overwrite to replace.")
+                return {'CANCELLED'}
+
+        octane_exec = resolve_octane_executable(props.octane_standalone_path)
+        if not octane_exec:
+            self.report({'ERROR'}, "[ShotManager] Invalid Octane Standalone path")
+            return {'CANCELLED'}
+
+        addon_dir = os.path.dirname(os.path.dirname(__file__))
+        script_path = os.path.join(addon_dir, 'standalone_scripts', 'ORBXmerger.lua')
+
+        manager = make_orbx_merge_manager(tasks, octane_exec, script_path, poll_interval=3.0)
+        bpy.app.timers.register(manager, first_interval=0.0)
+
+        self.report({'INFO'}, "[ShotManager] ORBX merging started.")
+        return {'FINISHED'}
+
+
+classes = (
+    LMB_OT_manual_orbx_merge,
+)
+
+
+def register():
+    for cls in classes:
+        bpy.utils.register_class(cls)
+
+
+def unregister():
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)

--- a/LMI_OctaneShotManager_Blender/properties.py
+++ b/LMI_OctaneShotManager_Blender/properties.py
@@ -12,6 +12,8 @@ from bpy.props import (
 from .Workflows.TAGs.tags_workflow import TagCollectionItem
 from .utils import resolve_octane_executable
 
+from .Workflows.manual_merge.manual_merge_workflow import ManualMergeSourceItem
+
 
 def _update_octane_path(self, context):
     """Resolve and store an absolute path to the Octane executable."""
@@ -199,3 +201,32 @@ class OctanePointCloudProperties(bpy.types.PropertyGroup):
         subtype='FILE_PATH',
         update=_update_octane_path,
     )
+
+    # Manual ORBX merge settings
+    show_manual_orbx_merge: BoolProperty(
+        name="Show Manual ORBX Merge",
+        description="Display manual ORBX merge settings",
+        default=False,
+    )
+    manual_merge_save_dir: StringProperty(
+        name="Save Directory",
+        description="Directory to store merged ORBX files",
+        subtype='DIR_PATH',
+    )
+    manual_merge_scene_name: StringProperty(
+        name="Scene Name",
+        description="Base name for merged ORBX files",
+        default="",
+    )
+    manual_merge_overwrite: BoolProperty(
+        name="Overwrite ORBX",
+        description="Allow overwriting merged ORBX files",
+        default=False,
+    )
+    manual_merge_destination: StringProperty(
+        name="Destination ORBX",
+        description="ORBX file used as destination for merging",
+        subtype='FILE_PATH',
+    )
+    manual_merge_sources: CollectionProperty(type=ManualMergeSourceItem)
+    manual_merge_sources_index: IntProperty(default=-1)

--- a/LMI_OctaneShotManager_Blender/registration.py
+++ b/LMI_OctaneShotManager_Blender/registration.py
@@ -13,6 +13,7 @@ from .exporters.orbx_merge import (
     LMB_OT_merge_selected_tags,
     LMB_OT_merge_all_tags,
 )
+from .exporters.orbx_manual_merge import LMB_OT_manual_orbx_merge
 from .Workflows.TAGs.tags_workflow import (
     TagCollectionItem,
     LMB_UL_tag_collections,
@@ -20,12 +21,19 @@ from .Workflows.TAGs.tags_workflow import (
     LMB_OT_tag_collection_remove,
     LMB_OT_cycle_tag_collection,
 )
+from .Workflows.manual_merge.manual_merge_workflow import (
+    ManualMergeSourceItem,
+    LMB_UL_manual_merge_sources,
+    LMB_OT_manual_merge_source_add,
+    LMB_OT_manual_merge_source_remove,
+)
 from .ui import POINTCLOUD_PT_panel
 
 classes = (
     # Register the PropertyGroup used by OctanePointCloudProperties first so
     # Blender can resolve the CollectionProperty reference on registration.
     TagCollectionItem,
+    ManualMergeSourceItem,
     OctanePointCloudProperties,
     LMB_OT_export_csv,
     LMB_OT_export_abc,
@@ -35,6 +43,10 @@ classes = (
     LMB_OT_merge_selected_tags,
     LMB_OT_merge_all_tags,
     LMB_UL_tag_collections,
+    LMB_UL_manual_merge_sources,
+    LMB_OT_manual_merge_source_add,
+    LMB_OT_manual_merge_source_remove,
+    LMB_OT_manual_orbx_merge,
     LMB_OT_tag_collection_add,
     LMB_OT_tag_collection_remove,
     LMB_OT_cycle_tag_collection,

--- a/LMI_OctaneShotManager_Blender/ui.py
+++ b/LMI_OctaneShotManager_Blender/ui.py
@@ -86,6 +86,24 @@ class POINTCLOUD_PT_panel(Panel):
             merge_box.operator('lmb.merge_all_tags', text='Merge all Tags', icon='EXPORT')
             layout.separator()
 
+        # Manual ORBX Merge
+        row = layout.row()
+        arrow = 'TRIA_DOWN' if p.show_manual_orbx_merge else 'TRIA_RIGHT'
+        row.prop(p, 'show_manual_orbx_merge', text="", icon=arrow, emboss=False)
+        row.label(text="Manual ORBX Merge", icon='SEQ_STRIP_META')
+        if p.show_manual_orbx_merge:
+            box = layout.box()
+            box.prop(p, 'manual_merge_save_dir')
+            box.prop(p, 'manual_merge_scene_name')
+            box.prop(p, 'manual_merge_overwrite')
+            box.prop(p, 'manual_merge_destination')
+            row2 = box.row()
+            row2.template_list('LMB_UL_manual_merge_sources', '', p, 'manual_merge_sources', p, 'manual_merge_sources_index')
+            col = row2.column(align=True)
+            col.operator('lmb.manual_merge_source_add', icon='ADD', text='')
+            col.operator('lmb.manual_merge_source_remove', icon='REMOVE', text='')
+            box.operator('lmb.manual_orbx_merge', text='Merge ORBX', icon='EXPORT')
+            layout.separator()
         # PointCloud Baker dropdown
         row = layout.row()
         arrow = 'TRIA_DOWN' if p.show_pointcloud_baker else 'TRIA_RIGHT'

--- a/Structure
+++ b/Structure
@@ -5,15 +5,19 @@ LMI_OctaneShotManager_Blender/
 ├── ui.py                                   # Panel layout and shared UI helpers
 ├── registration.py                         # Central register() / unregister()
 ├── Workflows/                              # Contains different workflows logic
-│   └── TAGs/                               # Contains logic and helpers related to tagging workflows
-        ├── utils.py                        # Helper functions for TAG workflow
-│       └── tags_workflow.py                # Logic for tagging workflow and related helpers
+│   ├── TAGs/                               # Contains logic and helpers related to tagging workflows
+│   │   ├── utils.py                        # Helper functions for TAG workflow
+│   │   └── tags_workflow.py                # Logic for tagging workflow and related helpers
+│   └── manual_merge/                       # Manual ORBX merge helpers and UI
+│       ├── utils.py                        # Build tasks for manual merging
+│       └── manual_merge_workflow.py        # PropertyGroup and UIList for manual merge
 ├── icons.py                                # Icon loading helpers
 ├── exporters/                              # Contains exporters logic
 │   ├── csv_export.py                       # CSV export operator & related helpers
 │   ├── abc_export.py                       # Alembic export operator & face_sets logic
 │   ├── orbx_export.py                      # Export ORBX files for tagged collections
-│   └── orbx_merge.py                      # Merge ORBX chunks using Octane
+│   ├── orbx_merge.py                       # Merge ORBX chunks using Octane
+│   └── orbx_manual_merge.py                # Operator for manual ORBX merging
 ├── standalone_scripts/                     # Contains standalone scripts for specific tasks
 │   └── ORBXmerger.lua                      # Tool for merging ORBX files
 ├── Icons/                                  # Contains icons used in the addon


### PR DESCRIPTION
## Summary
- add new workflow for manual ORBX merging
- support merging tasks utilities
- add ManualMergeSourceItem and related operators
- expose manual merge options in UI and properties
- implement manual merge operator
- register new classes and update project structure documentation

## Testing
- `python3 -m flake8`


------
https://chatgpt.com/codex/tasks/task_e_687a03aacc608320b9cf7d05c34b064d